### PR TITLE
added .cfignore for nicer cf behaviour if node_modules present

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
The .cfignore file will simply enable the 'cf push' command to ignore a local node_modules directory if one is present.

Closes #5 
